### PR TITLE
[8_11_4x] Shutdown solr cluster after the test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,5 @@ gradle.properties
 gradle/
 gradlew
 gradlew.bat
+target/
+lucene-solr-parent.iml

--- a/solr/core/src/test/org/apache/solr/handler/TestHdfsBackupRestoreCore.java
+++ b/solr/core/src/test/org/apache/solr/handler/TestHdfsBackupRestoreCore.java
@@ -145,20 +145,24 @@ public class TestHdfsBackupRestoreCore extends SolrCloudTestCase {
 
   @AfterClass
   public static void teardownClass() throws Exception {
-    IOUtils.closeQuietly(fs);
-    fs = null;
     try {
-      SolrTestCaseJ4.resetFactory();
+      SolrCloudTestCase.shutdownCluster();
     } finally {
-      try {
-        HdfsTestUtil.teardownClass(dfsCluster);
-      } finally {
-        dfsCluster = null;
-        System.clearProperty("solr.hdfs.home");
-        System.clearProperty("solr.hdfs.default.backup.path");
-        System.clearProperty("test.build.data");
-        System.clearProperty("test.cache.data");
-      }
+        IOUtils.closeQuietly(fs);
+        fs = null;
+        try {
+            SolrTestCaseJ4.resetFactory();
+        } finally {
+            try {
+                HdfsTestUtil.teardownClass(dfsCluster);
+            } finally {
+                dfsCluster = null;
+                System.clearProperty("solr.hdfs.home");
+                System.clearProperty("solr.hdfs.default.backup.path");
+                System.clearProperty("test.build.data");
+                System.clearProperty("test.cache.data");
+            }
+        }
     }
   }
 


### PR DESCRIPTION
This change will close the Solr cluster after the test completion. This is added in order to see whether it can resolve the test failures in the Jenkins builds.