### PR TITLE
[8_11_4x] Fix timeout issue with tests

### DIFF
--- a/solr/core/src/test/org/apache/solr/handler/admin/MetricsHistoryHandlerTest.java
+++ b/solr/core/src/test/org/apache/solr/handler/admin/MetricsHistoryHandlerTest.java
@@ -101,22 +101,26 @@ public class MetricsHistoryHandlerTest extends SolrCloudTestCase {
         .setPerReplicaState(SolrCloudTestCase.USE_PER_REPLICA_STATE);
     create.process(solrClient);
     CloudUtil.waitForState(cloudManager, "failed to create " + CollectionAdminParams.SYSTEM_COLL,
-        CollectionAdminParams.SYSTEM_COLL, CloudUtil.clusterShape(1, 1));
+        CollectionAdminParams.SYSTEM_COLL, 90, TimeUnit.SECONDS, CloudUtil.clusterShape(1, 1));
   }
 
   @AfterClass
   public static void teardown() throws Exception {
-    if (handler != null) {
-      handler.close();
+    try {
+      shutdownCluster();
+    } finally {
+      if (handler != null) {
+        handler.close();
+      }
+      if (simulated && cloudManager != null) {
+        cloudManager.close();
+      }
+      handler = null;
+      metricsHandler = null;
+      cloudManager = null;
+      metricManager = null;
+      solrClient = null;
     }
-    if (simulated) {
-      cloudManager.close();
-    }
-    handler = null;
-    metricsHandler = null;
-    cloudManager = null;
-    metricManager = null;
-    solrClient = null;
   }
 
   @Test


### PR DESCRIPTION
This pull request updates the test setup and teardown logic in `MetricsHistoryHandlerTest.java` to improve reliability and resource management. The most significant changes are in how the system collection creation is awaited and how resources are cleaned up after tests.

Test setup improvements:
* Changed the call to `CloudUtil.waitForState` to include a timeout of 90 seconds, making the test more robust against hanging during system collection creation.

Resource cleanup enhancements:
* Updated the `teardown` method to ensure `shutdownCluster()` is always called, even if exceptions occur, and added additional null checks before closing resources to prevent potential errors. 