### PR TITLE
[8_11_4x] Fix test failures

### DIFF
--- a/solr/core/src/java/org/apache/solr/cloud/CloudUtil.java
+++ b/solr/core/src/java/org/apache/solr/cloud/CloudUtil.java
@@ -186,6 +186,35 @@ public class CloudUtil {
    * This is a convenience method using the {@link #DEFAULT_TIMEOUT}
    *
    * @param cloudManager current instance of {@link SolrCloudManager}
+   * @param message     a message to report on failure
+   * @param wait        timeout value
+   * @param collection  the collection to watch
+   * @param predicate   a predicate to match against the collection state
+   */
+  public static long waitForState(final SolrCloudManager cloudManager,
+                                  final String message,
+                                  long wait,
+                                  final String collection,
+                                  final CollectionStatePredicate predicate) {
+    AtomicReference<DocCollection> state = new AtomicReference<>();
+    AtomicReference<Set<String>> liveNodesLastSeen = new AtomicReference<>();
+    try {
+      return waitForState(cloudManager, collection, wait, TimeUnit.SECONDS, (n, c) -> {
+        state.set(c);
+        liveNodesLastSeen.set(n);
+        return predicate.matches(n, c);
+      });
+    } catch (Exception e) {
+      throw new AssertionError(message + "\n" + "Live Nodes: " + liveNodesLastSeen.get() + "\nLast available state: " + state.get(), e);
+    }
+  }
+
+  /**
+   * Wait for a particular collection state to appear.
+   *
+   * This is a convenience method using the {@link #DEFAULT_TIMEOUT}
+   *
+   * @param cloudManager current instance of {@link SolrCloudManager}
    * @param collection  the collection to watch
    * @param wait timeout value
    * @param unit timeout unit

--- a/solr/core/src/test/org/apache/solr/handler/admin/MetricsHistoryHandlerTest.java
+++ b/solr/core/src/test/org/apache/solr/handler/admin/MetricsHistoryHandlerTest.java
@@ -83,7 +83,7 @@ public class MetricsHistoryHandlerTest extends SolrCloudTestCase {
     configureCluster(1)
         .addConfig("conf", configset("cloud-minimal"))
         .configure();
-    
+
     if (!simulated) {
       cloudManager = cluster.getJettySolrRunner(0).getCoreContainer().getZkController().getSolrCloudManager();
       metricManager = cluster.getJettySolrRunner(0).getCoreContainer().getMetricManager();
@@ -100,8 +100,8 @@ public class MetricsHistoryHandlerTest extends SolrCloudTestCase {
         "conf", 1, 1)
         .setPerReplicaState(SolrCloudTestCase.USE_PER_REPLICA_STATE);
     create.process(solrClient);
-    CloudUtil.waitForState(cloudManager, "failed to create " + CollectionAdminParams.SYSTEM_COLL,
-        CollectionAdminParams.SYSTEM_COLL, 90, TimeUnit.SECONDS, CloudUtil.clusterShape(1, 1));
+    CloudUtil.waitForState(cloudManager, "failed to create " + CollectionAdminParams.SYSTEM_COLL, 180,
+        CollectionAdminParams.SYSTEM_COLL, CloudUtil.clusterShape(1, 1));
   }
 
   @AfterClass


### PR DESCRIPTION
This pull request introduces a new convenience overload for the `waitForState` method in `CloudUtil`, simplifying how callers specify timeouts and improving error reporting. The main change is the addition of a new method that accepts a timeout in seconds and provides clearer failure messages. The test code is updated to use this new overload.

**API Improvements:**

* Added a new overload of `CloudUtil.waitForState` that accepts a timeout in seconds, a message for error reporting, and a `CollectionStatePredicate`, improving usability and error diagnostics.

**Test Updates:**

* Updated `MetricsHistoryHandlerTest.beforeClass` to use the new `waitForState` overload, passing the timeout in seconds and simplifying the method call.