### PR TITLE
Increasing thread lingering to 80s

### DIFF
--- a/solr/test-framework/src/java/org/apache/solr/SolrTestCaseJ4.java
+++ b/solr/test-framework/src/java/org/apache/solr/SolrTestCaseJ4.java
@@ -69,6 +69,7 @@ import java.util.stream.Collectors;
 import com.carrotsearch.randomizedtesting.RandomizedContext;
 import com.carrotsearch.randomizedtesting.RandomizedTest;
 import com.carrotsearch.randomizedtesting.TraceFormatting;
+import com.carrotsearch.randomizedtesting.annotations.ThreadLeakLingering;
 import com.carrotsearch.randomizedtesting.rules.SystemPropertiesRestoreRule;
 
 import org.apache.commons.io.FileUtils;
@@ -179,6 +180,7 @@ import static org.hamcrest.core.StringContains.containsString;
 @SuppressSysoutChecks(bugUrl = "Solr dumps tons of logs to console.")
 @SuppressFileSystems("ExtrasFS") // might be ok, the failures with e.g. nightly runs might be "normal"
 @RandomizeSSL()
+@ThreadLeakLingering(linger = 80000)
 
 public abstract class SolrTestCaseJ4 extends SolrTestCase {
 


### PR DESCRIPTION
- Sometimes Jetty can't stop for a minute. We need tests wait more than a minute in the worst case
to avoid test noise like ThreadLeakError: 1 thread leaked from SUITE scope.